### PR TITLE
fix: remove hardcoded developer paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,14 @@ Makefile
 # But do track hand-written payload Makefiles
 !stm32_payloads/**/Makefile
 
+# In-source build trees (if cmake is ever run from repo root instead of build/)
+/_deps/
+/generated/
+/pico-sdk/
+/pioasm/
+/pioasm-install/
+/pico_flash_region.ld
+
 # Build outputs
 *.elf
 *.bin

--- a/lpc2468/lpc2468_boot_timing_analysis.md
+++ b/lpc2468/lpc2468_boot_timing_analysis.md
@@ -255,8 +255,8 @@ This analysis was performed by:
 - `/tmp/lpc2468_bootrom_full.bin` - Complete boot ROM dump (72KB)
 - `/tmp/bootrom_full_disasm.txt` - ARM mode disassembly
 - `/tmp/boot_thumb_disasm.txt` - Thumb mode disassembly
-- `/home/addy/work/claude-code/raiden-pico/openocd/lpc2478_no_checksum.cfg` - OpenOCD config without auto-checksum
-- `/home/addy/work/claude-code/raiden-pico/images/crp*_test.{bin,hex}` - CRP test images
+- `openocd/lpc2478_no_checksum.cfg` - OpenOCD config without auto-checksum (relative to repo root)
+- `images/crp*_test.{bin,hex}` - CRP test images (relative to repo root)
 
 ---
 

--- a/scripts/auto_glitch_explorer.py
+++ b/scripts/auto_glitch_explorer.py
@@ -11,6 +11,10 @@ import csv
 import os
 from datetime import datetime
 
+# Resolve paths relative to this script so it runs from any checkout location
+SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_DIR = os.path.dirname(SCRIPTS_DIR)
+
 # Parameter sets to try
 PARAMETER_SETS = [
     # Set 1: Current best guess (crashes at V=300, early timing)
@@ -115,7 +119,7 @@ def run_parameter_set(param_set, iteration):
     # Create custom marathon script for this parameter set
     script_content = f"""
 import sys
-sys.path.insert(0, '/home/addy/work/claude-code/raiden-pico/scripts')
+sys.path.insert(0, {SCRIPTS_DIR!r})
 from glitch_marathon import *
 
 # Override parameter ranges
@@ -139,7 +143,7 @@ run_marathon_custom(voltage_range, pause_range, width_range, {HOURS_PER_SET}, '{
             cmd,
             stdout=log,
             stderr=subprocess.STDOUT,
-            cwd='/home/addy/work/claude-code/raiden-pico'
+            cwd=PROJECT_DIR
         )
 
     return proc, log_file, csv_file

--- a/scripts/sweep_delay.sh
+++ b/scripts/sweep_delay.sh
@@ -2,7 +2,7 @@
 # Sweep delay from 0 to 1000 in steps of 10 at 201V
 # Loop until SUCCESS is found
 
-cd /home/addy/work/claude-code/raiden-pico/scripts
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 while true; do
     for DELAY in $(seq 0 10 1000); do

--- a/scripts/test_bootloader_sync.py
+++ b/scripts/test_bootloader_sync.py
@@ -3,8 +3,9 @@
 Quick test to debug bootloader sync detection
 """
 
+import os
 import sys
-sys.path.insert(0, '/home/addy/work/claude-code/raiden-pico/scripts')
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from jtag_chipshouter_isp import RaidenPico
 

--- a/stm32_payloads/f4/test_payload.py
+++ b/stm32_payloads/f4/test_payload.py
@@ -9,13 +9,14 @@ The exploit has two stages:
 BOOT1 on F4 is an option bit, not a pin - only BOOT0 is controllable.
 """
 
+import os
 import subprocess
 import serial
 import time
 import sys
 import argparse
 
-PAYLOAD_PATH = "/home/addy/work/claude-code/raiden-pico/stm32_payloads/f4/payload.bin"
+PAYLOAD_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "payload.bin")
 PICO_PORT = "/dev/ttyACM0"
 PICO_BAUD = 115200
 


### PR DESCRIPTION
Replace absolute /home/addy/... paths with paths resolved relative to the script / repo root (__file__-derived or BASH_SOURCE), so the scripts and docs work from any checkout location.


Most likely will mess with your personal setup :)