### PR TITLE
feat: shared host-script tooling (colors + Rigol scope helpers)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,8 @@ pyserial>=3.5
 # scripts/stm32_dual_trace.py for DWT-cycle-count + ADC-shunt visualization.
 numpy>=1.20
 matplotlib>=3.4
+
+# Image handling for the Rigol scope viewers (rigol_view.py, rigol_scope_live.py,
+# rigol_screenshot.py) — screenshot capture + Tk preview (PIL.ImageTk; needs the
+# system tkinter / python3-tk package at runtime).
+Pillow>=9.0

--- a/scripts/colors.py
+++ b/scripts/colors.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+colors.py -- shared ANSI color helpers + a unified colorized argparse help formatter
+for the raiden-pico host scripts (nrf_*.py / pic_*.py / rigol_*.py).
+
+Colors auto-disable when stdout is not a TTY, when NO_COLOR is set (https://no-color.org),
+or when TERM=dumb -- so piped/redirected output and log files stay clean. Force on with
+CLICOLOR_FORCE=1.
+
+Output helpers (semantic = the unified scheme):
+    hdr(s)   bold cyan    -- section / banner headers
+    ok(s)    bold green   -- success
+    warn(s)  yellow       -- warnings
+    err(s)   bold red     -- errors
+    info(s)  cyan         -- informational
+    key(s)   dim          -- a field name
+    val(s)   bold         -- a field value
+    plus the plain styles: bold/dim/red/green/yellow/cyan/magenta/gray.
+
+Help formatter:
+    ColorHelpFormatter -- pass as argparse `formatter_class` for a uniform colored help.
+
+Misc:
+    strip(s) -- remove ANSI codes (used when teeing colored output to a file).
+"""
+import argparse
+import os
+import re
+import sys
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _color_enabled():
+    force = os.environ.get("CLICOLOR_FORCE")
+    if force not in (None, "", "0"):
+        return True
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if os.environ.get("TERM") == "dumb":
+        return False
+    try:
+        return sys.stdout.isatty()
+    except Exception:
+        return False
+
+
+ENABLED = _color_enabled()
+
+_SGR = {
+    "reset": "0", "bold": "1", "dim": "2", "italic": "3", "underline": "4",
+    "red": "31", "green": "32", "yellow": "33", "blue": "34",
+    "magenta": "35", "cyan": "36", "white": "37", "gray": "90",
+}
+
+
+def style(text, *names):
+    """Wrap `text` in the given SGR styles (no-op when colors are disabled)."""
+    if not ENABLED or not names:
+        return text
+    codes = ";".join(_SGR[n] for n in names if n in _SGR)
+    return f"\033[{codes}m{text}\033[0m" if codes else text
+
+
+def strip(text):
+    """Remove ANSI SGR codes from `text` (for writing colored output to a file)."""
+    return _ANSI_RE.sub("", text)
+
+
+# --- plain styles ---
+def bold(s):    return style(s, "bold")
+def dim(s):     return style(s, "dim")
+def red(s):     return style(s, "red")
+def green(s):   return style(s, "green")
+def yellow(s):  return style(s, "yellow")
+def cyan(s):    return style(s, "cyan")
+def magenta(s): return style(s, "magenta")
+def gray(s):    return style(s, "gray")
+
+# --- semantic (the unified scheme) ---
+def hdr(s):  return style(s, "bold", "cyan")
+def ok(s):   return style(s, "bold", "green")
+def warn(s): return style(s, "yellow")
+def err(s):  return style(s, "bold", "red")
+def info(s): return style(s, "cyan")
+def key(s):  return style(s, "dim")
+def val(s):  return style(s, "bold")
+
+
+# --- unified argparse help formatter ---
+# Post-process the rendered help so column widths (computed by argparse on PLAIN text)
+# stay correct -- ANSI is only injected afterwards. Extends RawDescriptionHelpFormatter
+# so module docstrings / examples keep their formatting.
+_OPT_RE = re.compile(r"(?<![\w-])(--?[A-Za-z][\w-]*)")     # -x / --long-opt tokens
+_HDR_RE = re.compile(r"^([A-Za-z][\w /+-]*:)\s*$")          # "options:", "Examples:", ...
+
+
+class ColorHelpFormatter(argparse.RawDescriptionHelpFormatter):
+    """Uniform colored argparse help: bold `usage:`, bold-yellow section/headers,
+    cyan option flags. Falls back to plain when colors are disabled."""
+    def format_help(self):
+        text = super().format_help()
+        if not ENABLED:
+            return text
+        out = []
+        for line in text.split("\n"):
+            m = _HDR_RE.match(line)
+            if m:                                   # a section / docstring header line
+                out.append(style(line, "bold", "yellow"))
+                continue
+            if line.startswith("usage:"):
+                line = style("usage:", "bold") + line[len("usage:"):]
+            line = _OPT_RE.sub(lambda mm: style(mm.group(1), "cyan"), line)
+            out.append(line)
+        return "\n".join(out)

--- a/scripts/rigol_scope_live.py
+++ b/scripts/rigol_scope_live.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+rigol_scope_live.py -- live Rigol scope capture loop: configure the channels/trigger,
+then repeatedly grab a screenshot to a viewable PNG. Headless (writes a PNG) -- pair with
+rigol_view.py to display it, or open the PNG in any image viewer.
+
+LAN-ONLY: talks to the Rigol over VXI-11 (`lxi`) and never opens the Pico serial port, so it
+runs in PARALLEL with an attack (nrf_attack.py / nrf_autopwn.py) without contention.
+
+The default channel setup is the nRF52840 glitch rig: CH1 = GP2 (the glitch pulse, used as the
+trigger) and CH2 = P0.13 (the boot marker), RUN / NORMAL sweep. Each attack shot fires GP2 so the
+scope re-triggers and the frame tracks the latest glitch; read boot survival off CH2 (marker rises
+= boot ok; marker gone = the glitch crashed the boot). Override --trig-ch/--trig-level/--tb for
+other rigs.
+
+Output goes to a per-target folder like the other tools (default scripts/nrf52840/scope_live.png);
+--dir picks another target (e.g. pic18) or a path. Refreshes every --interval seconds.
+
+Examples:
+  ./rigol_scope_live.py                            # CH1=GP2, CH2=P0.13, 50 us/div, 40 min
+  ./rigol_scope_live.py --interval 1 --secs 7200   # faster refresh, run 2 h
+  ./rigol_scope_live.py --tb 0.0001 --dir pic18    # 100 us/div, write into scripts/pic18/
+"""
+import argparse
+import os
+import subprocess
+import time
+
+from colors import ColorHelpFormatter
+from nrf_recovery import resolve_outdir   # shared per-target output-folder helper
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=ColorHelpFormatter)
+    ap.add_argument("--scope-ip", default="10.0.0.10", help="Rigol scope IP (lxi)")
+    ap.add_argument("--interval", type=float, default=2.0, help="seconds between screenshots")
+    ap.add_argument("--tb", default="0.00005", help="scope timebase, s/div (default 50us)")
+    ap.add_argument("--secs", type=float, default=2400.0, help="total run time, s")
+    ap.add_argument("--trig-ch", type=int, default=1, help="scope channel to trigger on (default 1 = GP2)")
+    ap.add_argument("--trig-level", type=float, default=1.5, help="trigger level, V")
+    ap.add_argument("--dir", default=None,
+                    help="destination folder: a target name (scripts/<name>/) or a path "
+                         "(default: scripts/nrf52840/)")
+    ap.add_argument("--out", default=None,
+                    help="viewable PNG to (re)write each frame (default: <dir>/scope_live.png)")
+    a = ap.parse_args()
+    out = a.out or os.path.join(resolve_outdir(a.dir), "scope_live.png")
+
+    def lxi(scpi, t=8):
+        r = subprocess.run(["lxi", "scpi", "-a", a.scope_ip, "-t", str(t), scpi],
+                           capture_output=True, text=True)
+        if r.returncode != 0:
+            raise RuntimeError(f"{scpi!r}: {r.stderr.strip()}")
+        return r.stdout.strip()
+
+    lxi(":CHANnel1:DISPlay ON"); lxi(":CHANnel1:COUPling DC")
+    lxi(":CHANnel1:SCALe 1.0"); lxi(":CHANnel1:OFFSet -2.0")     # CH1 (nRF rig: GP2 glitch pulse)
+    lxi(":CHANnel2:DISPlay ON"); lxi(":CHANnel2:COUPling DC")
+    lxi(":CHANnel2:SCALe 1.0"); lxi(":CHANnel2:OFFSet -2.0")     # CH2 (nRF rig: P0.13 marker)
+    lxi(f":TIMebase:MAIN:SCALe {a.tb}")
+    lxi(":TIMebase:MAIN:OFFSet 0")          # trigger centred; marker sits to its right
+    lxi(":TRIGger:MODE EDGE"); lxi(f":TRIGger:EDGE:SOURce CHANnel{a.trig_ch}")
+    lxi(":TRIGger:EDGE:SLOPe POSitive"); lxi(f":TRIGger:EDGE:LEVel {a.trig_level}")
+    lxi(":TRIGger:SWEep NORMal")
+    lxi(":RUN")
+    print(f"scope live: CH{a.trig_ch}=trigger, {a.tb}s/div, NORM/RUN -> {out} "
+          f"(refresh {a.interval}s, {a.secs:.0f}s total)")
+
+    raw = out + ".raw"
+    t0 = time.time(); n = 0
+    while time.time() - t0 < a.secs:
+        subprocess.run(["lxi", "screenshot", "-a", a.scope_ip, "-t", "15", raw],
+                       capture_output=True, text=True)
+        try:
+            from PIL import Image
+            Image.open(raw).save(out)
+        except Exception:
+            pass
+        n += 1
+        if n % 15 == 0:
+            print(f"[{int(time.time()-t0)}s] {n} frames")
+        time.sleep(a.interval)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nstopped")

--- a/scripts/rigol_screenshot.py
+++ b/scripts/rigol_screenshot.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+rigol_screenshot.py -- grab a Rigol scope display hardcopy over LXI and save a real
+PNG, in ONE flow.
+
+The Rigol hardcopy (`lxi screenshot`) is a BMP regardless of the file extension you
+give it, so every caller otherwise has to notice "this .png is actually a BMP" and
+convert it by hand. This grabs the BMP and converts it to a true PNG in one call.
+
+Output goes to a per-target destination folder, just like the nrf_*.py scripts: a
+bare filename lands in the destination (default scripts/nrf52840/). Use --dir to pick
+another target ("pic18" -> scripts/pic18/) or an explicit path; or pass a path with a
+directory as the filename and it is used as-is.
+
+Examples:
+  ./rigol_screenshot.py                         # -> scripts/nrf52840/rigol_screenshot.png
+  ./rigol_screenshot.py boot.png                # -> scripts/nrf52840/boot.png
+  ./rigol_screenshot.py boot.png --dir pic18    # -> scripts/pic18/boot.png
+  ./rigol_screenshot.py shots/run.png           # explicit path -> used as-is
+  ./rigol_screenshot.py --scope-ip 10.0.0.10 --timeout 20
+
+Importable (used by nrf_timing_marker.py / rigol_scope_live.py):
+  from rigol_screenshot import grab_png
+  grab_png("10.0.0.10", "/path/reset_timing.png")   # writes a true PNG, returns the path
+"""
+import argparse
+from colors import ColorHelpFormatter
+import os
+import subprocess
+import sys
+import tempfile
+
+from nrf_recovery import resolve_outdir   # shared per-target output-folder helper
+
+SCOPE_IP_DEFAULT = "10.0.0.10"
+
+
+def grab_png(scope_ip, out_path, timeout=15):
+    """Capture the Rigol display and write a TRUE PNG to out_path (extension forced to
+    .png; parent dir created if needed). Grabs a temp .bmp via `lxi screenshot`, then
+    converts with Pillow. Returns the final path; raises RuntimeError on capture
+    failure."""
+    out_path = os.path.splitext(out_path)[0] + ".png"
+    parent = os.path.dirname(out_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    fd, bmp = tempfile.mkstemp(suffix=".bmp")
+    os.close(fd)
+    try:
+        r = subprocess.run(["lxi", "screenshot", "-a", scope_ip, "-t", str(timeout), bmp],
+                           capture_output=True, text=True)
+        if r.returncode != 0 or not os.path.getsize(bmp):
+            raise RuntimeError(f"lxi screenshot failed: {r.stderr.strip() or 'empty file'}")
+        from PIL import Image
+        with Image.open(bmp) as img:
+            img.load()
+            img.save(out_path, "PNG")
+    finally:
+        try:
+            os.remove(bmp)
+        except OSError:
+            pass
+    return out_path
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=ColorHelpFormatter)
+    ap.add_argument("out", nargs="?", default="rigol_screenshot.png",
+                    help="output filename or path (ext forced to .png; default: rigol_screenshot.png)")
+    ap.add_argument("--dir", default=None,
+                    help="destination folder for a bare filename: a target name "
+                         "(scripts/<name>/) or a path (default: scripts/nrf52840/)")
+    ap.add_argument("--scope-ip", default=SCOPE_IP_DEFAULT, help="Rigol scope IP (lxi)")
+    ap.add_argument("--timeout", type=int, default=15, help="lxi capture timeout, s")
+    a = ap.parse_args()
+
+    out = a.out
+    if not os.path.dirname(out):                       # bare filename -> destination folder
+        out = os.path.join(resolve_outdir(a.dir), out)
+    try:
+        print(f"saved {grab_png(a.scope_ip, out, a.timeout)}")
+    except Exception as e:
+        sys.exit(f"error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rigol_view.py
+++ b/scripts/rigol_view.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+rigol_view.py -- live Rigol scope viewer: an auto-refreshing window so you can watch
+captures as they are taken.
+
+Two modes:
+  watch (default)  display a PNG that the capture scripts overwrite each shot. Uses NO
+                   scope access, so it never clashes with a running capture/sweep.
+  --poll           pull a fresh screenshot from the scope yourself every --interval
+                   seconds. Use only when no capture script is running (two LXI clients
+                   at once can stall each other).
+
+The watched file lives in a per-target destination folder, like the nrf_*.py scripts:
+<dir>/<file> (default scripts/nrf52840/scope_live.png). Point --dir at another target
+("pic18" -> scripts/pic18/) or an explicit path.
+
+Examples:
+  ./rigol_view.py                              # watch scripts/nrf52840/scope_live.png
+  ./rigol_view.py --poll                       # mirror the scope live (~2.5 s)
+  ./rigol_view.py --dir pic18                  # watch scripts/pic18/scope_live.png
+  ./rigol_view.py --file timing_marker.png     # watch a specific capture
+
+Leave it open in a corner of the screen; close the window to quit.
+"""
+import argparse
+from colors import ColorHelpFormatter
+import os
+import subprocess
+import time
+import tkinter as tk
+
+from PIL import Image, ImageTk
+
+from nrf_recovery import resolve_outdir   # shared per-target output-folder helper
+
+
+def pull_from_scope(scope_ip, live_path):
+    """poll mode: grab a screenshot from the scope into live_path (BMP -> PNG)."""
+    tmp = live_path + ".poll.bmp"
+    r = subprocess.run(["lxi", "screenshot", "-a", scope_ip, "-t", "8", tmp],
+                       capture_output=True, text=True)
+    if r.returncode == 0:
+        try:
+            Image.open(tmp).save(live_path)
+        except Exception:
+            pass
+    try:
+        os.remove(tmp)
+    except OSError:
+        pass
+
+
+class Viewer:
+    def __init__(self, root, live_path, poll, scope_ip, interval):
+        self.root = root
+        self.live = live_path
+        self.poll = poll
+        self.scope_ip = scope_ip
+        self.interval = interval
+        self.mtime = 0
+        self.last_poll = 0.0
+        self.tk_img = None
+        root.title("rigol scope (waiting for first capture…)")
+        self.lbl = tk.Label(root, bg="black")
+        self.lbl.pack(fill="both", expand=True)
+        self.tick()
+
+    def tick(self):
+        now = time.time()
+        if self.poll and now - self.last_poll > self.interval:
+            self.last_poll = now
+            pull_from_scope(self.scope_ip, self.live)
+        try:
+            m = os.path.getmtime(self.live)
+            if m != self.mtime:
+                self.mtime = m
+                self.tk_img = ImageTk.PhotoImage(Image.open(self.live))
+                self.lbl.configure(image=self.tk_img)
+                tag = "[poll]" if self.poll else f"[watch {os.path.basename(self.live)}]"
+                self.root.title(f"rigol scope — updated "
+                                f"{time.strftime('%H:%M:%S', time.localtime(m))}  {tag}")
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            self.root.title(f"rigol scope — view error: {e}")
+        self.root.after(400, self.tick)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=ColorHelpFormatter)
+    ap.add_argument("--poll", action="store_true",
+                    help="pull screenshots from the scope yourself (no capture script running)")
+    ap.add_argument("--dir", default=None,
+                    help="destination folder: a target name (scripts/<name>/) or a path "
+                         "(default: scripts/nrf52840/)")
+    ap.add_argument("--file", default="scope_live.png", help="PNG filename to watch/update")
+    ap.add_argument("--scope-ip", default="10.0.0.10", help="Rigol scope IP (lxi, poll mode)")
+    ap.add_argument("--interval", type=float, default=2.5, help="poll interval, s")
+    a = ap.parse_args()
+
+    live = os.path.join(resolve_outdir(a.dir), a.file)
+    root = tk.Tk()
+    root.geometry("820x520")
+    Viewer(root, live, a.poll, a.scope_ip, a.interval)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add scripts/colors.py, a small shared helper for colored CLI output (auto-disables when stdout is not a TTY), and three Rigol scope utilities (live view, screenshot, waveform view) that use it. colors.py is the shared dependency imported by the per-target scripts.

We all like colors :)  
I personally have a hard time reading a wall of white text.   Call it old age :)

This PR must be merged before the  `nRF52/pic18/efm32`  targets PR that is coming,